### PR TITLE
Feat/stdio transport support

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -155,9 +155,8 @@ def list_test_runs(
             "test-run",
             {"page": page, **params},
             tuskr_client.RequestMethod.GET,
-            ext_account_id=ctx.get_state("ext_account_id"),
-            ext_access_token=ctx.get_state("ext_access_token"),
-        )
+            ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
+            ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"),        )
 
     # Fetch all pages and filter for incomplete runs client-side,
     # returning a trimmed payload to stay under MCP transport size limits.
@@ -231,8 +230,8 @@ def create_test_run(
             "assignedTo": assigned_to,
         },
         tuskr_client.ReuqestMethod.POST,
-        ext_account_id=ctx.get_state("ext_account_id"),
-        ext_access_token=ctx.get_state("ext_access_token"),
+        ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
+        ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"),
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -106,8 +106,8 @@ def list_projects(
         "project",
         {"page": page, **params},
         tuskr_client.RequestMethod.GET,
-        ext_account_id=ctx.get_state("ext_account_id"),
-        ext_access_token=ctx.get_state("ext_access_token"),
+        ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
+        ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"),
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -32,11 +32,21 @@ class UserTokenHandler(Middleware):
         return result
 
     def retrieve_and_apply_token(self, context: MiddlewareContext):
-        # get request to reade headers
-        request = context.fastmcp_context.request_context.request
+        """
+        In stdio mode there is no HTTP request/headers, so fall back to None
+        and let the tool functions fall back to env vars instead
+        """
+        try:
+            request = context.fastmcp_context.request_context.request
+            headers = request.headers
+        except Exception:
+            logger.info("No HTTP request context (stdio mode), skipping header extraction")
+            context.fastmcp_context.set_state("ext_access_token", None)
+            context.fastmcp_context.set_state("ext_account_id", None)
+            return
 
         # Read access token
-        auth_header = request.headers.get("Authorization")
+        auth_header = headers.get("Authorization")
         token = None
 
         if auth_header:
@@ -53,12 +63,11 @@ class UserTokenHandler(Middleware):
         # Try to retrieve account id.
         # It is optional, because account id can be set through env variable
         # in organization on the deployment
-        account_header = request.headers.get("Account-ID")
+        account_header = headers.get("Account-ID")
         account_id = None
 
         if account_header:
             account_id = account_header.strip()
-
             logger.info(f"Got account id: {account_id}")
         else:
             logger.info("Account id is not defined")

--- a/src/main.py
+++ b/src/main.py
@@ -39,7 +39,9 @@ class UserTokenHandler(Middleware):
             request = context.fastmcp_context.request_context.request
             headers = request.headers
         except Exception:
-            logger.info("No HTTP request context (stdio mode), skipping header extraction")
+            logger.info(
+                "No HTTP request context (stdio mode), skipping header extraction"
+            )
             context.fastmcp_context.set_state("ext_access_token", None)
             context.fastmcp_context.set_state("ext_account_id", None)
             return
@@ -82,10 +84,10 @@ mcp.add_middleware(UserTokenHandler())
 
 @mcp.tool
 def list_projects(
-        ctx: Context,
-        filter_name: str = None,
-        filter_status: str = None,
-        page: int = 1,
+    ctx: Context,
+    filter_name: str = None,
+    filter_status: str = None,
+    page: int = 1,
 ):
     """
     Retrives list of projects based on various filter criteria.
@@ -105,21 +107,23 @@ def list_projects(
         "project",
         {"page": page, **params},
         tuskr_client.RequestMethod.GET,
-        ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
-        ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"),
+        ext_account_id=ctx.get_state("ext_account_id")
+        or os.environ.get("TUSKR_ACCOUNT_ID"),
+        ext_access_token=ctx.get_state("ext_access_token")
+        or os.environ.get("TUSKR_ACCESS_TOKEN"),
     )
 
 
 @mcp.tool
 def list_test_runs(
-        ctx: Context,
-        filter_project,
-        filter_name: str = None,
-        filter_key: str = None,
-        filter_status: str = None,
-        filter_assigned_to: str = None,
-        filter_incomplete: bool = False,
-        page: int = 1,
+    ctx: Context,
+    filter_project,
+    filter_name: str = None,
+    filter_key: str = None,
+    filter_status: str = None,
+    filter_assigned_to: str = None,
+    filter_incomplete: bool = False,
+    page: int = 1,
 ):
     """
     Retrieves list of test runs of a project with support for various filters.
@@ -154,8 +158,11 @@ def list_test_runs(
             "test-run",
             {"page": page, **params},
             tuskr_client.RequestMethod.GET,
-            ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
-            ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"), )
+            ext_account_id=ctx.get_state("ext_account_id")
+            or os.environ.get("TUSKR_ACCOUNT_ID"),
+            ext_access_token=ctx.get_state("ext_access_token")
+            or os.environ.get("TUSKR_ACCESS_TOKEN"),
+        )
 
     # Fetch all pages and filter for incomplete runs client-side,
     # returning a trimmed payload to stay under MCP transport size limits.
@@ -174,17 +181,19 @@ def list_test_runs(
         for run in rows:
             percent = run.get("percentDone", 100)
             if percent < 100:
-                incomplete.append({
-                    "id": run.get("id"),
-                    "key": run.get("key"),
-                    "name": run.get("name"),
-                    "percentDone": percent,
-                    "totalTestCaseCount": run.get("totalTestCaseCount", 0),
-                    "doneTestCaseCount": run.get("doneTestCaseCount", 0),
-                    "assignedTo": run.get("assignedTo"),
-                    "deadline": run.get("deadline"),
-                    "status": run.get("status"),
-                })
+                incomplete.append(
+                    {
+                        "id": run.get("id"),
+                        "key": run.get("key"),
+                        "name": run.get("name"),
+                        "percentDone": percent,
+                        "totalTestCaseCount": run.get("totalTestCaseCount", 0),
+                        "doneTestCaseCount": run.get("doneTestCaseCount", 0),
+                        "assignedTo": run.get("assignedTo"),
+                        "deadline": run.get("deadline"),
+                        "status": run.get("status"),
+                    }
+                )
         meta = data.get("meta", {})
         if current_page >= meta.get("pages", 1):
             break
@@ -195,14 +204,14 @@ def list_test_runs(
 
 @mcp.tool
 def create_test_run(
-        ctx: Context,
-        name: str,
-        project: str,
-        test_case_inclusion_type: str,
-        test_cases: List[str] = None,
-        description: str = "",
-        deadline: str = "",
-        assigned_to: str = "",
+    ctx: Context,
+    name: str,
+    project: str,
+    test_case_inclusion_type: str,
+    test_cases: List[str] = None,
+    description: str = "",
+    deadline: str = "",
+    assigned_to: str = "",
 ):
     """
     Creates a new test run in a project.
@@ -229,8 +238,10 @@ def create_test_run(
             "assignedTo": assigned_to,
         },
         tuskr_client.ReuqestMethod.POST,
-        ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
-        ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"),
+        ext_account_id=ctx.get_state("ext_account_id")
+        or os.environ.get("TUSKR_ACCOUNT_ID"),
+        ext_access_token=ctx.get_state("ext_access_token")
+        or os.environ.get("TUSKR_ACCESS_TOKEN"),
     )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,6 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 import tuskr_client
 
-
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
 )
@@ -83,10 +82,10 @@ mcp.add_middleware(UserTokenHandler())
 
 @mcp.tool
 def list_projects(
-    ctx: Context,
-    filter_name: str = None,
-    filter_status: str = None,
-    page: int = 1,
+        ctx: Context,
+        filter_name: str = None,
+        filter_status: str = None,
+        page: int = 1,
 ):
     """
     Retrives list of projects based on various filter criteria.
@@ -113,14 +112,14 @@ def list_projects(
 
 @mcp.tool
 def list_test_runs(
-    ctx: Context,
-    filter_project,
-    filter_name: str = None,
-    filter_key: str = None,
-    filter_status: str = None,
-    filter_assigned_to: str = None,
-    filter_incomplete: bool = False,
-    page: int = 1,
+        ctx: Context,
+        filter_project,
+        filter_name: str = None,
+        filter_key: str = None,
+        filter_status: str = None,
+        filter_assigned_to: str = None,
+        filter_incomplete: bool = False,
+        page: int = 1,
 ):
     """
     Retrieves list of test runs of a project with support for various filters.
@@ -156,7 +155,7 @@ def list_test_runs(
             {"page": page, **params},
             tuskr_client.RequestMethod.GET,
             ext_account_id=ctx.get_state("ext_account_id") or os.environ.get("TUSKR_ACCOUNT_ID"),
-            ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"),        )
+            ext_access_token=ctx.get_state("ext_access_token") or os.environ.get("TUSKR_ACCESS_TOKEN"), )
 
     # Fetch all pages and filter for incomplete runs client-side,
     # returning a trimmed payload to stay under MCP transport size limits.
@@ -196,14 +195,14 @@ def list_test_runs(
 
 @mcp.tool
 def create_test_run(
-    ctx: Context,
-    name: str,
-    project: str,
-    test_case_inclusion_type: str,
-    test_cases: List[str] = None,
-    description: str = "",
-    deadline: str = "",
-    assigned_to: str = "",
+        ctx: Context,
+        name: str,
+        project: str,
+        test_case_inclusion_type: str,
+        test_cases: List[str] = None,
+        description: str = "",
+        deadline: str = "",
+        assigned_to: str = "",
 ):
     """
     Creates a new test run in a project.


### PR DESCRIPTION
Support stdio transport with environment variable credentials
Summary
Enables the MCP server to run under --transport stdio by fixing a middleware crash and allowing tool functions to read credentials from environment variables when HTTP headers are unavailable.
Problem
When starting the server with --transport stdio (as required by Claude Desktop and most local MCP clients), every tool call fails with:
'NoneType' object has no attribute 'headers'
Two issues cause this:

Middleware crash — The UserTokenHandler middleware unconditionally accesses context.fastmcp_context.request_context.request.headers. Under stdio transport there is no HTTP request object, so this raises before any tool handler runs.
No credential source in stdio mode — Even if the middleware were guarded, the tool functions only read credentials from ctx.get_state(...), which is populated from HTTP headers. In stdio mode those states are None, and the downstream tuskr_client.send() call then crashes trying to build the URL.

The project already documents TUSKR_ACCESS_TOKEN and TUSKR_ACCOUNT_ID environment variables in .env.example, but nothing currently consumes them in stdio mode.
Changes

src/main.py — middleware: Wrap request_context.request access in try/except. When no HTTP context exists (stdio mode), log it, set both state values to None, and return early so tool handlers can fall back to env vars.
src/main.py — tool functions: In list_projects, list_test_runs, and create_test_run, fall back to os.environ.get("TUSKR_ACCOUNT_ID") and os.environ.get("TUSKR_ACCESS_TOKEN") when context state is None. HTTP transport behavior is unchanged — headers still take precedence.

Testing
Verified locally with Claude Desktop as the MCP client over stdio transport:

list_projects — returns all projects correctly using env-var credentials
list_test_runs — returns filtered test runs (tested with filter_name and filter_project)
HTTP transport regression check — middleware still extracts Bearer token and Account-ID headers when present; ctx.get_state(...) takes precedence over env vars via the or chain

Usage example
With this change, a stdio MCP client can now be configured like:
json{
  "mcpServers": {
    "tuskr": {
      "command": "python",
      "args": ["/path/to/tuskr-mcp-server/src/main.py", "--transport", "stdio"],
      "env": {
        "TUSKR_ACCESS_TOKEN": "<token>",
        "TUSKR_ACCOUNT_ID": "<account-id>"
      }
    }
  }
}
Backwards compatibility
Fully backwards compatible. HTTP transport continues to read from Authorization and Account-ID headers. The env-var fallback only activates when ctx.get_state(...) returns None.
