### PR TITLE
feat: add filter_incomplete option to list_test_runs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -110,6 +110,7 @@ def list_test_runs(
     filter_key: str = None,
     filter_status: str = None,
     filter_assigned_to: str = None,
+    filter_incomplete: bool = False,
     page: int = 1,
 ):
     """
@@ -118,11 +119,17 @@ def list_test_runs(
     Args:
         filter_project: specifies the project ID to filter the test runs associated with a particular project
         filter_name: to filter test runs with name containing the specified value
-        fller_key: to filter test runs with key containing the specified value
+        filter_key: to filter test runs with key containing the specified value
         filter_status: to filter test runs by their status. Two supported values 'active' or 'archived'
         filter_assigned_to: id of the user to whom test runs are assigned
+        filter_incomplete: if True, fetches all pages and returns only test runs that are not 100% complete,
+            with a trimmed payload (id, key, name, percentDone, counts, assignee, deadline, status).
+            When False (default), returns the raw paginated response from the Tuskr API.
         page: controls number of records in output, every page contains 100 records. Default is 1.
+            Ignored when filter_incomplete is True.
     """
+    import json
+
     params = {"filter[project]": filter_project}
 
     if filter_name:
@@ -134,13 +141,49 @@ def list_test_runs(
     if filter_assigned_to:
         params["filter[assignedTo]"] = filter_assigned_to
 
-    return tuskr_client.send(
-        "test-run",
-        {"page": page, **params},
-        tuskr_client.RequestMethod.GET,
-        ext_account_id=ctx.get_state("ext_account_id"),
-        ext_access_token=ctx.get_state("ext_access_token"),
-    )
+    if not filter_incomplete:
+        return tuskr_client.send(
+            "test-run",
+            {"page": page, **params},
+            tuskr_client.RequestMethod.GET,
+            ext_account_id=ctx.get_state("ext_account_id"),
+            ext_access_token=ctx.get_state("ext_access_token"),
+        )
+
+    # Fetch all pages and filter for incomplete runs client-side,
+    # returning a trimmed payload to stay under MCP transport size limits.
+    incomplete = []
+    current_page = 1
+    while True:
+        raw = tuskr_client.send(
+            "test-run",
+            {"page": current_page, **params},
+            tuskr_client.RequestMethod.GET,
+            ext_account_id=ctx.get_state("ext_account_id"),
+            ext_access_token=ctx.get_state("ext_access_token"),
+        )
+        data = json.loads(raw)
+        rows = data.get("rows", [])
+        for run in rows:
+            percent = run.get("percentDone", 100)
+            if percent < 100:
+                incomplete.append({
+                    "id": run.get("id"),
+                    "key": run.get("key"),
+                    "name": run.get("name"),
+                    "percentDone": percent,
+                    "totalTestCaseCount": run.get("totalTestCaseCount", 0),
+                    "doneTestCaseCount": run.get("doneTestCaseCount", 0),
+                    "assignedTo": run.get("assignedTo"),
+                    "deadline": run.get("deadline"),
+                    "status": run.get("status"),
+                })
+        meta = data.get("meta", {})
+        if current_page >= meta.get("pages", 1):
+            break
+        current_page += 1
+
+    return json.dumps({"rows": incomplete, "count": len(incomplete)})
 
 
 @mcp.tool


### PR DESCRIPTION
Add filter_incomplete option to list_test_runs
Summary
Adds a new optional filter_incomplete parameter to list_test_runs that returns only test runs that are not yet 100% complete, with a trimmed response payload.
Problem
Two real-world issues hit the current list_test_runs implementation on projects with many active test runs:

No server-side completion filter. The Tuskr REST API supports filtering test runs by name, key, status (active/archived), and assignee — but not by completion percentage. Finding "which test runs still need attention" is a common workflow, but currently requires fetching everything and inspecting percentDone manually.
Response size exceeds MCP transport limits. The Tuskr API embeds deeply-nested state into every test run row (full project object, full assigned-user object with their complete application state, all suite sections, etc.). On a project with 139 active runs, a single page response is ~1.5MB — over the 1MB MCP transport cap — so the tool call fails before any filtering can happen client-side.

Changes

New parameter filter_incomplete: bool = False on list_test_runs.
When filter_incomplete=True:

Auto-paginates through all result pages using the existing meta.pages field
Filters client-side for runs where percentDone < 100
Returns a trimmed payload containing only: id, key, name, percentDone, totalTestCaseCount, doneTestCaseCount, assignedTo, deadline, status
The page parameter is ignored (all pages are fetched)


When filter_incomplete=False (default): behavior is unchanged — the raw paginated response is returned exactly as before.
Also fixes a docstring typo: fller_key → filter_key (spotted while editing the same function).

Example
Without the flag, asking "show me incomplete test runs" on a busy project fails with a size-limit error. With the flag:
pythonlist_test_runs(
    filter_project="9a4a9ef9-cd42-48e8-9f84-1fd4ec861184",
    filter_status="active",
    filter_incomplete=True,
)
Returns something like:
json{
  "rows": [
    {
      "id": "17ba611d-...",
      "key": "R-412",
      "name": "CMS 1.23.3",
      "percentDone": 84,
      "totalTestCaseCount": 274,
      "doneTestCaseCount": 232,
      "assignedTo": { "fullName": "Nana Babayan", ... },
      "deadline": null,
      "status": "active"
    },
    ...
  ],
  "count": 13
}
For the same project this is ~3KB instead of ~1.5MB+.
Testing
Verified against a real Tuskr tenant with 139 active test runs across multiple projects:

filter_incomplete=True — correctly returns only runs with percentDone < 100, response fits under the transport limit, counts match manual verification
filter_incomplete=False (default) — identical output to before this change, page parameter still honored
Combined with other filters (filter_status="active", filter_name, etc.) — all filters compose correctly and apply on every paginated request

Backwards compatibility
Fully backwards compatible. The new parameter defaults to False, so existing callers see no behavioral change.
Notes for the reviewer

Client-side filtering is used because the Tuskr API does not expose a completion filter. If it did, server-side would be preferable.
The trimmed payload is only returned in the filter_incomplete=True branch. I considered also trimming in the default branch, but that would be a breaking change — happy to do it in a separate MR if you'd like.