### PR TITLE
fix: correct create_test_run typo and POST body serialization

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 import tuskr_client
 
+
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.INFO
 )
@@ -237,7 +238,7 @@ def create_test_run(
             "deadline": deadline,
             "assignedTo": assigned_to,
         },
-        tuskr_client.ReuqestMethod.POST,
+        tuskr_client.RequestMethod.POST,
         ext_account_id=ctx.get_state("ext_account_id")
         or os.environ.get("TUSKR_ACCOUNT_ID"),
         ext_access_token=ctx.get_state("ext_access_token")

--- a/src/tuskr_client.py
+++ b/src/tuskr_client.py
@@ -35,7 +35,14 @@ def send(
     headers = {"Authorization": f"Bearer {access_token}"}
 
     if method == RequestMethod.POST:
-        response = requests.post(url, headers=headers, data=body)
+        # Tuskr's REST API expects POST bodies as JSON wrapped in a top-level
+        # "data" key (see https://tuskr.app/kb/latest/api). Setting the
+        # Content-Type header and using requests' json= keyword handles both.
+        response = requests.post(
+            url,
+            headers={**headers, "Content-Type": "application/json"},
+            json={"data": body},
+        )
     else:
         response = requests.get(url, headers=headers, params=body)
 

--- a/test/test_tuskr_client.py
+++ b/test/test_tuskr_client.py
@@ -41,8 +41,11 @@ class TestSend:
         assert result == "executed"
         requests.post.assert_called_once_with(
             f"{expected_base_url}/create_report",
-            headers={"Authorization": f"Bearer {access_token}"},
-            data="some body",
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+            json={"data": "some body"},
         )
 
     def test_get(self, mocker, mock_envs):


### PR DESCRIPTION
Fixes two bugs that together prevent create_test_run from being usable at all against a real Tuskr tenant.

Bug 1 — AttributeError on every call
src/main.py references tuskr_client.ReuqestMethod.POST (note the transposed u and e). tuskr_client.py only defines RequestMethod, so any call to create_test_run crashes immediately with AttributeError: module 'tuskr_client' has no attribute 'ReuqestMethod'.

Bug 2 — POST body serialization is incompatible with the Tuskr API
Even after fixing the typo, tuskr_client.send() sends POST bodies via requests.post(url, data=body):

Passing a Python dict to data= produces an application/x-www-form-urlencoded body. The Tuskr REST API expects application/json.
No Content-Type header is set, so Tuskr receives the request as form-encoded.
The Tuskr API example in [the documentation](https://tuskr.app/kb/latest/api) shows POST payloads wrapped in a top-level "data" key (e.g. {"data": {"name": "Endgame v3", ...}}). The current code sends fields at the top level, so the server rejects the request.

Changes

src/main.py — fix typo ReuqestMethod → RequestMethod.
src/tuskr_client.py — switch POST to requests.post(url, headers={..., "Content-Type": "application/json"}, json={"data": body}).
test/test_tuskr_client.py — update test_post assertion to match the new (correct) request shape.

Scope note: GET is intentionally left unchanged
Only the POST branch is modified. GET requests pass the dict via requests' params= keyword, which URL-encodes it into the query string (e.g. ?page=1&filter[status]=active) — GET has no request body, so the JSON serialization and "data" wrapper issues don't apply. list_projects and list_test_runs have been working against the live Tuskr API with the existing GET behavior, which confirms this.
Backwards compatibility
The typo fix is purely a bugfix — no caller could have been relying on it. The serialization change was required for create_test_run to work at all against the real API; there was no previous state where a POST call succeeded.
Out of scope
I noticed one more potentially problematic behavior in tuskr_client.send() — os.environ.get("TUSKR_ACCOUNT_ID", ext_account_id) gives the env var precedence over the caller-supplied value, but the caller's value (from HTTP headers) should likely win. Keeping that for a separate PR since it's orthogonal and has behavioral implications for HTTP-transport users that deserve their own discussion.