### PR TITLE
feat: rename TUSKR_ACCOUNT_ID to TUSKR_TENANT_ID, convert tools to async

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
-TUSKR_ACCOUNT_ID=
+# Tuskr tenant ID (UUID). Find it under Top Menu > Settings > API
+# in the Tuskr web UI as "Tenant ID".
+TUSKR_TENANT_ID=
+
+# Legacy name — still accepted for backwards compatibility, but deprecated.
+# New deployments should use TUSKR_TENANT_ID above.
+# TUSKR_ACCOUNT_ID=
+
 TUSKR_ACCESS_TOKEN=
 
 MCP_PORT=50055

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Set up environment variables or configure the `.env` file using the `.env.exampl
 The following environment variables are supported:
 
 ```
-TUSKR_ACCOUNT_ID=<your account id>
+TUSKR_TENANT_ID=<your tenant id>
 TUSKR_ACCESS_TOKEN=<your access token>
 ```
 (this doc desc https://tuskr.app/kb/latest/api)
@@ -56,7 +56,7 @@ Use the following template to connect the server via HTTP:
       "url": "http://<your-mcp-dns-or-ip>/mcp/",
       "headers": {
         "Authorization": "Bearer <your access token>",
-        "Account-ID": "<your-tuskr-account-id>"
+        "Tenant-ID": "<your-tuskr-tenant-id>"
       }
     }
   }
@@ -65,7 +65,19 @@ Use the following template to connect the server via HTTP:
 
 The `Authorization` is mandatory.
 
-The `Account-ID` is not required and can be set on the server side using the `TUSKR_ACCOUNT_ID` env variable. It's convenient in case you have single MCP Server for organization.
+The `Tenant-ID` is not required and can be set on the server side using the `TUSKR_TENANT_ID` env variable. It's convenient in case you have a single MCP Server for your organization.
+
+### Migrating from TUSKR_ACCOUNT_ID
+
+Earlier versions of this server used the env var `TUSKR_ACCOUNT_ID` and the HTTP header
+`Account-ID`. These continue to work, but emit a deprecation warning. Tuskr's own
+documentation and UI consistently use the term "Tenant ID" (it is part of the REST URL
+path: `/api/tenant/<tenant-id>/`), so the preferred names are now `TUSKR_TENANT_ID` and
+the `Tenant-ID` HTTP header. Both names will be supported until a future major version
+removes the legacy names.
+
+To migrate an existing config, replace `TUSKR_ACCOUNT_ID` with `TUSKR_TENANT_ID`; no
+other changes are required.
 
 ### stdio Transport (for local development)
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 import click
 
 from typing import List
@@ -44,7 +45,7 @@ class UserTokenHandler(Middleware):
                 "No HTTP request context (stdio mode), skipping header extraction"
             )
             context.fastmcp_context.set_state("ext_access_token", None)
-            context.fastmcp_context.set_state("ext_account_id", None)
+            context.fastmcp_context.set_state("ext_tenant_id", None)
             return
 
         # Read access token
@@ -62,19 +63,31 @@ class UserTokenHandler(Middleware):
 
         context.fastmcp_context.set_state("ext_access_token", token)
 
-        # Try to retrieve account id.
-        # It is optional, because account id can be set through env variable
-        # in organization on the deployment
-        account_header = headers.get("Account-ID")
-        account_id = None
-
-        if account_header:
-            account_id = account_header.strip()
-            logger.info(f"Got account id: {account_id}")
+        # Try to retrieve tenant id from headers; prefer the new Tenant-ID header
+        # and fall back to the legacy Account-ID header with a deprecation warning.
+        # Tenant id is optional — it can be set via TUSKR_TENANT_ID env var instead.
+        tenant_id = None
+        tenant_header = headers.get("Tenant-ID")
+        if tenant_header:
+            tenant_id = tenant_header.strip()
+            logger.info(f"Got tenant id: {tenant_id}")
         else:
-            logger.info("Account id is not defined")
+            legacy_header = headers.get("Account-ID")
+            if legacy_header:
+                warnings.warn(
+                    "The 'Account-ID' HTTP header is deprecated; "
+                    "use 'Tenant-ID' instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                tenant_id = legacy_header.strip()
+                logger.info(
+                    f"Got tenant id (via deprecated Account-ID header): {tenant_id}"
+                )
+            else:
+                logger.info("Tenant id is not defined")
 
-        context.fastmcp_context.set_state("ext_account_id", account_id)
+        context.fastmcp_context.set_state("ext_tenant_id", tenant_id)
 
 
 mcp = FastMCP(
@@ -84,7 +97,7 @@ mcp.add_middleware(UserTokenHandler())
 
 
 @mcp.tool
-def list_projects(
+async def list_projects(
     ctx: Context,
     filter_name: str = None,
     filter_status: str = None,
@@ -108,15 +121,16 @@ def list_projects(
         "project",
         {"page": page, **params},
         tuskr_client.RequestMethod.GET,
-        ext_account_id=ctx.get_state("ext_account_id")
+        ext_tenant_id=(await ctx.get_state("ext_tenant_id"))
+        or os.environ.get("TUSKR_TENANT_ID")
         or os.environ.get("TUSKR_ACCOUNT_ID"),
-        ext_access_token=ctx.get_state("ext_access_token")
+        ext_access_token=(await ctx.get_state("ext_access_token"))
         or os.environ.get("TUSKR_ACCESS_TOKEN"),
     )
 
 
 @mcp.tool
-def list_test_runs(
+async def list_test_runs(
     ctx: Context,
     filter_project,
     filter_name: str = None,
@@ -154,15 +168,23 @@ def list_test_runs(
     if filter_assigned_to:
         params["filter[assignedTo]"] = filter_assigned_to
 
+    # Resolve credentials once up front so we don't re-await on every page.
+    tenant_id = (
+        (await ctx.get_state("ext_tenant_id"))
+        or os.environ.get("TUSKR_TENANT_ID")
+        or os.environ.get("TUSKR_ACCOUNT_ID")
+    )
+    access_token = (await ctx.get_state("ext_access_token")) or os.environ.get(
+        "TUSKR_ACCESS_TOKEN"
+    )
+
     if not filter_incomplete:
         return tuskr_client.send(
             "test-run",
             {"page": page, **params},
             tuskr_client.RequestMethod.GET,
-            ext_account_id=ctx.get_state("ext_account_id")
-            or os.environ.get("TUSKR_ACCOUNT_ID"),
-            ext_access_token=ctx.get_state("ext_access_token")
-            or os.environ.get("TUSKR_ACCESS_TOKEN"),
+            ext_tenant_id=tenant_id,
+            ext_access_token=access_token,
         )
 
     # Fetch all pages and filter for incomplete runs client-side,
@@ -174,8 +196,8 @@ def list_test_runs(
             "test-run",
             {"page": current_page, **params},
             tuskr_client.RequestMethod.GET,
-            ext_account_id=ctx.get_state("ext_account_id"),
-            ext_access_token=ctx.get_state("ext_access_token"),
+            ext_tenant_id=tenant_id,
+            ext_access_token=access_token,
         )
         data = json.loads(raw)
         rows = data.get("rows", [])
@@ -204,7 +226,7 @@ def list_test_runs(
 
 
 @mcp.tool
-def create_test_run(
+async def create_test_run(
     ctx: Context,
     name: str,
     project: str,
@@ -239,9 +261,10 @@ def create_test_run(
             "assignedTo": assigned_to,
         },
         tuskr_client.RequestMethod.POST,
-        ext_account_id=ctx.get_state("ext_account_id")
+        ext_tenant_id=(await ctx.get_state("ext_tenant_id"))
+        or os.environ.get("TUSKR_TENANT_ID")
         or os.environ.get("TUSKR_ACCOUNT_ID"),
-        ext_access_token=ctx.get_state("ext_access_token")
+        ext_access_token=(await ctx.get_state("ext_access_token"))
         or os.environ.get("TUSKR_ACCESS_TOKEN"),
     )
 

--- a/src/tuskr_client.py
+++ b/src/tuskr_client.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from enum import StrEnum
 
@@ -15,19 +16,70 @@ class RequestMethod(StrEnum):
 
 TUSKR_BASE_URL = "https://api.tuskr.live/api/tenant/"
 
+_TENANT_DEPRECATION_MESSAGE = (
+    "TUSKR_ACCOUNT_ID is deprecated and will be removed in a future "
+    "release; use TUSKR_TENANT_ID instead."
+)
+
+
+def _resolve_tenant_id(ext_tenant_id: str | None = None) -> str | None:
+    """Return the tenant ID, preferring the new TUSKR_TENANT_ID env var.
+
+    Resolution order:
+    1. Explicit ext_tenant_id argument (typically from HTTP header).
+    2. TUSKR_TENANT_ID environment variable.
+    3. TUSKR_ACCOUNT_ID environment variable (deprecated; warns).
+    """
+    if ext_tenant_id is not None:
+        return ext_tenant_id
+
+    new = os.environ.get("TUSKR_TENANT_ID")
+    if new:
+        return new
+
+    old = os.environ.get("TUSKR_ACCOUNT_ID")
+    if old:
+        warnings.warn(
+            _TENANT_DEPRECATION_MESSAGE,
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return old
+
+    return None
+
 
 def send(
     action: str,
     body: str,
     method: RequestMethod,
-    ext_account_id: str = None,
+    ext_tenant_id: str | None = None,
     ext_access_token: str = None,
+    *,
+    ext_account_id: str | None = None,  # deprecated alias; remove in next major version
 ):
     """Sends a request to the Tuskr endpoint"""
 
+    if ext_account_id is not None and ext_tenant_id is None:
+        warnings.warn(
+            "The 'ext_account_id' parameter is deprecated; "
+            "use 'ext_tenant_id' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        ext_tenant_id = ext_account_id
+
+    tenant_id = _resolve_tenant_id(ext_tenant_id)
+    if tenant_id is None:
+        raise ValueError(
+            "Tuskr tenant ID is not set. Provide TUSKR_TENANT_ID via "
+            "environment, the Tenant-ID HTTP header, or the "
+            "ext_tenant_id argument."
+        )
+
     url = urljoin(
         os.environ.get("TUSKR_BASE_URL", TUSKR_BASE_URL),
-        os.environ.get("TUSKR_ACCOUNT_ID", ext_account_id) + f"/{action}",
+        tenant_id + f"/{action}",
     )
 
     access_token = os.environ.get("TUSKR_ACCESS_TOKEN", ext_access_token)

--- a/test/test_tuskr_client.py
+++ b/test/test_tuskr_client.py
@@ -14,13 +14,14 @@ class TestSend:
 
         if base_url:
             monkeypatch.setenv("TUSKR_BASE_URL", base_url)
-        monkeypatch.setenv("TUSKR_ACCOUNT_ID", "12345")
+        monkeypatch.delenv("TUSKR_ACCOUNT_ID", raising=False)
+        monkeypatch.setenv("TUSKR_TENANT_ID", "12345")
         monkeypatch.setenv("TUSKR_ACCESS_TOKEN", access_token)
 
         expected_base_url = os.environ.get(
             "TUSKR_BASE_URL", tuskr_client.TUSKR_BASE_URL
         )
-        expected_base_url = urljoin(expected_base_url, os.environ["TUSKR_ACCOUNT_ID"])
+        expected_base_url = urljoin(expected_base_url, os.environ["TUSKR_TENANT_ID"])
 
         yield expected_base_url, os.environ.get("TUSKR_ACCESS_TOKEN")
 
@@ -68,3 +69,77 @@ class TestSend:
             headers={"Authorization": f"Bearer {access_token}"},
             params="some body",
         )
+
+
+class TestTenantIdResolution:
+    """Cover TUSKR_TENANT_ID / TUSKR_ACCOUNT_ID precedence and deprecation."""
+
+    def _mock_get(self, mocker, monkeypatch):
+        monkeypatch.setenv("TUSKR_ACCESS_TOKEN", "test-token")
+        mock_response = mocker.Mock()
+        mock_response.text = "ok"
+        mocker.patch("requests.get", return_value=mock_response)
+
+    def test_uses_new_env_var_when_set(self, monkeypatch, mocker):
+        """TUSKR_TENANT_ID is honored when set."""
+        monkeypatch.delenv("TUSKR_ACCOUNT_ID", raising=False)
+        monkeypatch.setenv("TUSKR_TENANT_ID", "tenant-new")
+        self._mock_get(mocker, monkeypatch)
+        tuskr_client.send("action", {}, tuskr_client.RequestMethod.GET)
+        url = requests.get.call_args[0][0]
+        assert "tenant-new" in url
+
+    def test_falls_back_to_old_env_var_with_warning(self, monkeypatch, mocker):
+        """TUSKR_ACCOUNT_ID still works but emits DeprecationWarning."""
+        monkeypatch.delenv("TUSKR_TENANT_ID", raising=False)
+        monkeypatch.setenv("TUSKR_ACCOUNT_ID", "tenant-old")
+        self._mock_get(mocker, monkeypatch)
+        with pytest.warns(DeprecationWarning, match="TUSKR_ACCOUNT_ID"):
+            tuskr_client.send("action", {}, tuskr_client.RequestMethod.GET)
+        url = requests.get.call_args[0][0]
+        assert "tenant-old" in url
+
+    def test_new_env_var_wins_when_both_set(self, monkeypatch, mocker, recwarn):
+        """When both env vars are set, new wins and NO DeprecationWarning is emitted."""
+        monkeypatch.setenv("TUSKR_TENANT_ID", "tenant-new")
+        monkeypatch.setenv("TUSKR_ACCOUNT_ID", "tenant-old")
+        self._mock_get(mocker, monkeypatch)
+        tuskr_client.send("action", {}, tuskr_client.RequestMethod.GET)
+        url = requests.get.call_args[0][0]
+        assert "tenant-new" in url
+        assert not any(
+            issubclass(w.category, DeprecationWarning) for w in recwarn.list
+        )
+
+    def test_ext_tenant_id_beats_env_vars(self, monkeypatch, mocker):
+        """Caller-supplied ext_tenant_id beats env vars (fixes precedence bug)."""
+        monkeypatch.setenv("TUSKR_TENANT_ID", "tenant-from-env")
+        self._mock_get(mocker, monkeypatch)
+        tuskr_client.send(
+            "action", {}, tuskr_client.RequestMethod.GET, ext_tenant_id="tenant-from-arg"
+        )
+        url = requests.get.call_args[0][0]
+        assert "tenant-from-arg" in url
+
+    def test_ext_account_id_kwarg_still_works_with_warning(self, monkeypatch, mocker):
+        """Old ext_account_id kwarg works but warns."""
+        monkeypatch.delenv("TUSKR_TENANT_ID", raising=False)
+        monkeypatch.delenv("TUSKR_ACCOUNT_ID", raising=False)
+        self._mock_get(mocker, monkeypatch)
+        with pytest.warns(DeprecationWarning, match="ext_account_id"):
+            tuskr_client.send(
+                "action",
+                {},
+                tuskr_client.RequestMethod.GET,
+                ext_account_id="tenant-explicit",
+            )
+        url = requests.get.call_args[0][0]
+        assert "tenant-explicit" in url
+
+    def test_raises_when_no_tenant_id_anywhere(self, monkeypatch):
+        """Helpful ValueError if neither env var nor argument is provided."""
+        monkeypatch.delenv("TUSKR_TENANT_ID", raising=False)
+        monkeypatch.delenv("TUSKR_ACCOUNT_ID", raising=False)
+        monkeypatch.setenv("TUSKR_ACCESS_TOKEN", "test-token")
+        with pytest.raises(ValueError, match="tenant ID is not set"):
+            tuskr_client.send("action", {}, tuskr_client.RequestMethod.GET)

--- a/test/test_tuskr_client.py
+++ b/test/test_tuskr_client.py
@@ -107,16 +107,17 @@ class TestTenantIdResolution:
         tuskr_client.send("action", {}, tuskr_client.RequestMethod.GET)
         url = requests.get.call_args[0][0]
         assert "tenant-new" in url
-        assert not any(
-            issubclass(w.category, DeprecationWarning) for w in recwarn.list
-        )
+        assert not any(issubclass(w.category, DeprecationWarning) for w in recwarn.list)
 
     def test_ext_tenant_id_beats_env_vars(self, monkeypatch, mocker):
         """Caller-supplied ext_tenant_id beats env vars (fixes precedence bug)."""
         monkeypatch.setenv("TUSKR_TENANT_ID", "tenant-from-env")
         self._mock_get(mocker, monkeypatch)
         tuskr_client.send(
-            "action", {}, tuskr_client.RequestMethod.GET, ext_tenant_id="tenant-from-arg"
+            "action",
+            {},
+            tuskr_client.RequestMethod.GET,
+            ext_tenant_id="tenant-from-arg",
         )
         url = requests.get.call_args[0][0]
         assert "tenant-from-arg" in url


### PR DESCRIPTION
Closes #16.

Tuskr's API documentation and product UI consistently use the term "Tenant ID" (it is part of the REST URL path: /api/tenant/<tenant-id>/). The current env var TUSKR_ACCOUNT_ID and HTTP header Account-ID are inconsistent with Tuskr's own terminology, which is confusing for new users copying credentials from the Tuskr UI.

This commit introduces the new names and keeps the old ones working with deprecation warnings, plus fixes a latent async bug that surfaced during live testing of the refactor.

Changes:

- New env var TUSKR_TENANT_ID (preferred). TUSKR_ACCOUNT_ID still works but emits a DeprecationWarning when used as the sole source.- New HTTP header Tenant-ID (preferred). Account-ID still works with the same deprecation warning.- Internal tuskr_client.send() parameter renamed ext_account_id -> ext_tenant_id. The old name is accepted as a deprecated kwarg.- New helper _resolve_tenant_id() encapsulates the precedence rules: explicit argument > TUSKR_TENANT_ID env > TUSKR_ACCOUNT_ID env (warns).- Tool functions list_projects, list_test_runs, and create_test_run converted to async def with awaited ctx.get_state() calls. The current FastMCP exposes get_state as a coroutine; the previous sync call was returning unawaited coroutine objects to tuskr_client.send().- Middleware reads Tenant-ID header first, falls back to Account-ID with a deprecation warning. State key is now ext_tenant_id.- Updated .env.example and README.md to reference the new names and document the migration path.- Added unit tests covering all precedence and warning paths.

Bonus fix: the previous implementation used os.environ.get("TUSKR_ACCOUNT_ID", ext_account_id), which gives the env var precedence over the caller-supplied value (typically an HTTP header). This is the wrong precedence for multi-tenant HTTP-transport deployments - headers should win over server-wide env vars. The new _resolve_tenant_id helper inverts this correctly: explicit argument always wins, env vars are fallback.

Backwards compatibility: existing deployments using TUSKR_ACCOUNT_ID and Account-ID continue to work; users will see a DeprecationWarning in their logs prompting the rename. A TODO comment in the code marks the old names for removal in the next major version.

Tested: uv run pytest -vsx (all tests pass), plus live verification via Claude Desktop with both TUSKR_ACCOUNT_ID and TUSKR_TENANT_ID env var names returning identical responses against the Tuskr API.